### PR TITLE
correcting the template syntax

### DIFF
--- a/beginner-linux/part-two.md
+++ b/beginner-linux/part-two.md
@@ -264,7 +264,7 @@ We will not go into all the details here but we can use some filters to just ins
 Let's get the list of layers:
 
 ```.term1
-docker image inspect --format "{{ "{{ json .RootFS.Layers "}}}}" alpine
+docker image inspect --format "{{ json .RootFS.Layers }}" alpine
 ```
 
 Alpine is just a small base OS image so there's just one layer:
@@ -276,7 +276,7 @@ Alpine is just a small base OS image so there's just one layer:
 New let's look at our custom Hello image. You will need the image ID (use `docker image ls` if you need to look it up):
 
 ```
-docker image inspect --format "{{ "{{ json .RootFS.Layers "}}}}" <image ID>
+docker image inspect --format "{{ json .RootFS.Layers }}" <image ID>
 ```
 
 Our Hello image is a bit more interesting (your sha256 hashes will vary):


### PR DESCRIPTION
Correcting the template syntax for the `inspect` command in the documentation